### PR TITLE
FIX quick fix to get ms accuracy

### DIFF
--- a/iotqatools/simulators/listen/listen.js
+++ b/iotqatools/simulators/listen/listen.js
@@ -167,7 +167,8 @@ var srv =function(){
                                 //console.log('# Notification Data: ' + data);
                                 // get current time
                                 var now = new Date();
-                                var current = dateFormat(now, "isoDateTime");
+                                //var current = dateFormat(now, "isoDateTime");
+                                var current = dateFormat(now, "yyyy-mm-dd'T'HH:MM:ssl");
                                 
                                 try {
                                     var context = JSON.parse(data);
@@ -178,13 +179,17 @@ var srv =function(){
                                     for (var att in atts){
                                             if (atts[att].name == "TimeInstant"){
                                                 var received = atts[att].value;
-                                                var time = dateFormat(received, "isoDateTime");
+                                                //var time = dateFormat(received, "isoDateTime");
+                                                var time = dateFormat(received, "yyyy-mm-dd'T'HH:MM:ssl");
                                                 console.log("# TimeInstant  NOW: "+ current + " RECEIVED: " + time); 
 
                                                 //calculate DIFF
-                                                var startDate = moment(time);
-                                                var endDate = moment(current);
-                                                var secondsDiff = endDate.diff(startDate, 'seconds');
+                                                //var startDate = moment(time);
+                                                //var endDate = moment(current);
+                                                var startDate = moment(received);
+                                                var endDate = moment(now);
+                                                //var secondsDiff = endDate.diff(startDate, 'seconds');
+                                                var secondsDiff = endDate.diff(startDate);
                                                 console.log("# Diff: "+ secondsDiff);
                                             }
                                     


### PR DESCRIPTION
(Thanks to @crbrox for the fix!)

This is a way of get time diff in miliseconds, which is needed in some scenarios (i.e. listen.js and CB topologically close in low-load scenarios).

However, probably this is not the best fix for this and it could improved in the following way:
- Use the `-t` parameter to specify accuracy level, either `-t s` o `-t ms`. This way, the script will be also useful in scenarios where the spected delay is in the order of seconds.
- It should be analyzed if the same functionality could be achieved using just `Date` class in JavaScript, without needing the `moment` library. @crbrox could have some suggestion regarding this, please contact him.
