### PR TITLE
Amend library to send utf-8

### DIFF
--- a/iotqatools/cb_utils.py
+++ b/iotqatools/cb_utils.py
@@ -934,7 +934,7 @@ class CbNgsi10Utils(object):
 
         if payload is not None:
             if self.check_json:
-                parameters.update({'data': json.dumps(payload)})
+                parameters.update({'data': json.dumps(payload, ensure_ascii=False).encode('utf-8')})
             else:
                 parameters.update({'data': payload})
 


### PR DESCRIPTION
Amend to allow tests to send payloads in utf-8. CB only accepts utf-8
