### PR TITLE
ADD configurable log level for the iotqatools library

### DIFF
--- a/iotqatools/ckan_utils.py
+++ b/iotqatools/ckan_utils.py
@@ -44,7 +44,7 @@ class CKANUtils:
         :param port: ckan listen port
         :param url: url to include in the resources creation
         :param protocol: ckan protocol (e.g. http, https)
-        :param verbosity: verbosity level ('CRITICAL','ERROR', 'WARNING', 'INFO', 'DEBUG', 'NOTSET')
+        :param verbosity: verbosity level ('CRITICAL','ERROR', 'WARNING', 'INFO', 'DEBUG')
         :param default_headers: default headers for every requests to be sent to ckan
         """
         # initialize logger

--- a/iotqatools/helpers_utils.py
+++ b/iotqatools/helpers_utils.py
@@ -369,3 +369,12 @@ def get_type_value(value):
                 return value, "Unicode"
             else:
                 return value, "String"
+
+class LogLevelConfiguration:
+    """
+    Class to hold the log level to used by the library. Maybe this is not the best approach
+    to hold just an static variable but it suffices...
+
+    In addition, not sure if this file is the best place for this class or it should be put in its own .py
+    """
+    default_log_level = 'DEBUG'

--- a/iotqatools/iot_logger.py
+++ b/iotqatools/iot_logger.py
@@ -25,12 +25,14 @@ please contact with::[iot_support@tid.es]
 __author__ = 'xvc'
 
 import logging
+from iotqatools.helpers_utils import LogLevelConfiguration
 
 
-def get_logger(name, level='DEBUG', verbose=False, file=False, filename='', formatter=None):
+def get_logger(name, level=None, verbose=False, file=False, filename='', formatter=None):
     """
     :param name: Name of the logging module
-    :param level: Verbosity level (default DEBUG). Possible values ['CRITICAL','ERROR', 'WARNING', 'INFO', 'DEBUG', 'NOTSET')
+    :param level: Verbosity level (default None). Possible values [None, 'CRITICAL','ERROR', 'WARNING', 'INFO', 'DEBUG'].
+        If None is used then default level (from LogLevelConfiguration class) is used.
     :param verbose: Formatter adds time and logger name to log info. True for verbose active (default False).
     :param file: Create/update the logger adding a File handler
     :param filename: If file is True, indicate the filename
@@ -41,8 +43,13 @@ def get_logger(name, level='DEBUG', verbose=False, file=False, filename='', form
     logger = logging.getLogger(name)
     # Do not pass throw parents handlers
     logger.propagate = False
+    # Set log level
+    if level is not None:
+        lvl = level
+    else:
+        lvl = LogLevelConfiguration.default_log_level
     try:
-        logger.setLevel(level)
+        logger.setLevel(lvl)
     except ValueError as e:
         get_logger(__name__, 'ERROR').error(str(e))
         return
@@ -67,7 +74,7 @@ def get_logger(name, level='DEBUG', verbose=False, file=False, filename='', form
     else:
         new_handler = logging.StreamHandler()
 
-    new_handler.setLevel(level)
+    new_handler.setLevel(lvl)
 
     # Create formatter or use one passed
     if formatter is not None and isinstance(formatter, logging.Formatter):


### PR DESCRIPTION
This PR makes log level configurable. The static variable `default_log_level` at `LogLevelConfiguration` is used for that, although if you think there are a better approach, please provide feedback. The user program will set this variable accordinly (in the case of iotp-pqa, this is done based in the properties.json file).

@AlvaroVega @manucarrace @mcarracedo 