### PR TITLE
check tup before use it

### DIFF
--- a/iotqatools/mysql_utils.py
+++ b/iotqatools/mysql_utils.py
@@ -275,12 +275,12 @@ class Mysql:
         rows = []
         for elements in results:
             tup = elements
-        for element in tup:
-            if element is None:
-                empty_values.append(True)
-            else:
-                empty_values.append(False)
-                rows.append(element)
+            for element in tup:
+                if element is None:
+                    empty_values.append(True)
+                else:
+                    empty_values.append(False)
+                    rows.append(element)
         count = 0
         rows = tuple(rows)
         for cd in cur.description:


### PR DESCRIPTION
http://ci-iot-deven-01.hi.inet/jenkins/view/QA_CI/job/QACI_INT_CB_004_cb2mysql/lastCompletedBuild/testReport/features.TS03_cbflows.004_cb2mysql/IOT-cb004%20CB%20connector%20to%20relational%20DB/cb00402_Entities_updated_in_CB_with_several_attributes_should_be_stored_in_MYSQL_____1_1_/

```
Failing for the past 5 builds (Since Failed#709 )
Took 12 sec.
add description
Error Message

local variable 'tup' referenced before assignment

Stacktrace


Failing step: Then MYSQL values "32;1.1;23" for attributes "temperature;test1;fill_level" should be updated ... failed in 0.003s
Location: tests/features/TS03_cbflows/004_cb2mysql.feature:60
Traceback (most recent call last):
  File "/var/develenv/jenkins/jobs/QACI_INT_CB_004_cb2mysql/workspace/jenknsenv/lib/python2.7/site-packages/behave/model.py", line 1329, in run
    match.run(runner.context)
  File "/var/develenv/jenkins/jobs/QACI_INT_CB_004_cb2mysql/workspace/jenknsenv/lib/python2.7/site-packages/behave/matchers.py", line 98, in run
    self.func(context, *args, **kwargs)
  File "tests/steps/mysql_steps.py", line 204, in mysql_values_for_attributes_should_be_updated
    table_name=context.remember["table_name"])
  File "/var/develenv/jenkins/jobs/QACI_INT_CB_004_cb2mysql/workspace/jenknsenv/lib/python2.7/site-packages/iotqatools/mysql_utils.py", line 278, in table_pretty_output
    for element in tup:
UnboundLocalError: local variable 'tup' referenced before assignment
```