### PR TITLE
Update orchestator_utils.py

### DIFF
--- a/iotqatools/orchestator_utils.py
+++ b/iotqatools/orchestator_utils.py
@@ -39,11 +39,13 @@ class Orchestrator(object):
 
     log = get_logger('Orchestrator', 'ERROR')
 
-    def __init__(self, host='127.0.0.1', port='8084', protocol='http', verify=False):
+    def __init__(self, host='127.0.0.1', port='8084', protocol='http', verify=False, ks_host='127.0.0.1', ks_port='5001'):
         self.url = '%s://%s:%s' % (protocol, host, port)
         self.ip = host
         self.verify = verify
         self.timeout = 120 # should be greather than harakiri orc option
+        self.ks_host = ks_host
+        self.ks_port = ks_port
 
     def send(self, method, url, headers=None, payload=None, query=None, verify=None):
         """
@@ -109,8 +111,8 @@ class Orchestrator(object):
             service_id = KeystoneUtils.get_service_id(admin_domain_user,
                                                       admin_domain_password,
                                                       service_name,
-                                                      ip=self.ip,
-                                                      port=5001)
+                                                      ip=self.ks_host,
+                                                      port=self.ks_port)
             if not isinstance(service_id, requests.Response):
                 return service_id
 


### PR DESCRIPTION
This PR allows orchestrator constructor to receive keystone host information. This in case they are not on the same host.