### PR TITLE
Update package.json

### DIFF
--- a/iotqatools/simulators/listen/package.json
+++ b/iotqatools/simulators/listen/package.json
@@ -23,7 +23,7 @@
     "dependencies": {
         "moment": "2.29.1",
         "dateformat": "4.5.1",
-        "mqtt": "4.2.8"
+        "mqtt": "4.2.7"
     },
     "keywords": [
         "qa",


### PR DESCRIPTION
4.2.7 uses previous version of ws dep: https://github.com/mqttjs/MQTT.js/commit/997944380702c17d6b144b499685e591b3178c11

fix for:


iotp-pqa1    | Servers Starts at Tue Oct  5 13:46:50 2021 
iotp-pqa1    |  * Running on https://0.0.0.0:10032/
iotp-pqa1    |  * Restarting with reloader
iotp-pqa1    |  * Running on http://0.0.0.0:10031/
iotp-pqa1    |  * Restarting with reloader
iotp-pqa1    | listen@0.0.4 /opt/simulators/listen
iotp-pqa1    | +-- dateformat@4.5.1 
iotp-pqa1    | +-- moment@2.29.1 
iotp-pqa1    | `-- mqtt@4.2.8 
iotp-pqa1    |   +-- UNMET PEER DEPENDENCY bufferutil@^4.0.1
iotp-pqa1    |   +-- commist@1.1.0 
iotp-pqa1    |   | `-- leven@2.1.0 
iotp-pqa1    |   +-- concat-stream@2.0.0 
iotp-pqa1    |   | +-- buffer-from@1.1.2 
iotp-pqa1    |   | `-- typedarray@0.0.6 
iotp-pqa1    |   +-- debug@4.3.2 
iotp-pqa1    |   | `-- ms@2.1.2 
iotp-pqa1    |   +-- duplexify@4.1.2 
iotp-pqa1    |   | +-- end-of-stream@1.4.4 
iotp-pqa1    |   | `-- stream-shift@1.0.1 
iotp-pqa1    |   +-- help-me@3.0.0 
iotp-pqa1    |   | `-- glob@7.2.0 
iotp-pqa1    |   |   +-- fs.realpath@1.0.0 
iotp-pqa1    |   |   +-- inflight@1.0.6 
iotp-pqa1    |   |   +-- minimatch@3.0.4 
iotp-pqa1    |   |   | `-- brace-expansion@1.1.11 
iotp-pqa1    |   |   |   +-- balanced-match@1.0.2 
iotp-pqa1    |   |   |   `-- concat-map@0.0.1 
iotp-pqa1    |   |   `-- path-is-absolute@1.0.1 
iotp-pqa1    |   +-- inherits@2.0.4 
iotp-pqa1    |   +-- minimist@1.2.5 
iotp-pqa1    |   +-- mqtt-packet@6.10.0 
iotp-pqa1    |   | +-- bl@4.1.0 
iotp-pqa1    |   | | `-- buffer@5.7.1 
iotp-pqa1    |   | |   +-- base64-js@1.5.1 
iotp-pqa1    |   | |   `-- ieee754@1.2.1 
iotp-pqa1    |   | `-- process-nextick-args@2.0.1 
iotp-pqa1    |   +-- pump@3.0.0 
iotp-pqa1    |   | `-- once@1.4.0 
iotp-pqa1    |   |   `-- wrappy@1.0.2 
iotp-pqa1    |   +-- readable-stream@3.6.0 
iotp-pqa1    |   | +-- string_decoder@1.3.0 
iotp-pqa1    |   | | `-- safe-buffer@5.2.1 
iotp-pqa1    |   | `-- util-deprecate@1.0.2 
iotp-pqa1    |   +-- reinterval@1.1.0 
iotp-pqa1    |   +-- split2@3.2.2 
iotp-pqa1    |   +-- UNMET PEER DEPENDENCY utf-8-validate@^5.0.2
iotp-pqa1    |   +-- ws@7.5.5 
iotp-pqa1    |   `-- xtend@4.0.2 
iotp-pqa1    | 
iotp-pqa1    | npm WARN ws@7.5.5 requires a peer of bufferutil@^4.0.1 but none was installed.
iotp-pqa1    | npm WARN ws@7.5.5 requires a peer of utf-8-validate@^5.0.2 but none was installed.
iotp-pqa1    | npm WARN listen@0.0.4 No license field.
iotp-pqa1    | /opt/simulators/listen/node_modules/ws/lib/websocket.js:414
iotp-pqa1    |       ...options
iotp-pqa1    |       ^^^
iotp-pqa1    | 
iotp-pqa1    | SyntaxError: Unexpected token ...
iotp-pqa1    |     at createScript (vm.js:56:10)
iotp-pqa1    |     at Object.runInThisContext (vm.js:97:10)
iotp-pqa1    |     at Module._compile (module.js:549:28)
iotp-pqa1    |     at Object.Module._extensions..js (module.js:586:10)
iotp-pqa1    |     at Module.load (module.js:494:32)
iotp-pqa1    |     at tryModuleLoad (module.js:453:12)
iotp-pqa1    |     at Function.Module._load (module.js:445:3)
iotp-pqa1    |     at Module.require (module.js:504:17)
iotp-pqa1    |     at require (internal/module.js:20:19)
iotp-pqa1    |     at Object.<anonymous> (/opt/simulators/listen/node_modules/ws/index.js:3:19)
iotp-pqa1    | INFO: I'm alive... <20211005_135652>
iotp-pqa1    | INFO: I'm alive... <20211005_140654>
iotp-pqa1    | INFO: I'm alive... <20211005_141656>
