### PR TITLE
do not use parse location and parse datetime in cep rules

### DIFF
--- a/iotqatools/cep_utils.py
+++ b/iotqatools/cep_utils.py
@@ -407,10 +407,8 @@ class CEP:
         if "location_x" in rule_properties:  # geo-location
             #text = u'%s Math.pow((cast(cast(%s__x?,String),float) - %s), 2) + Math.pow((cast(cast(%s__y?,String),float) - %s), 2) %s Math.pow(%s,2) and' % \
             #       (text, rule_properties["attr_name"], rule_properties["location_x"], rule_properties["attr_name"], rule_properties["location_y"], rule_properties["attr_op"], rule_properties["location_ratio"])
-            text = u'%s Math.pow((cast(cast(location.get(cast("coordinates",String)),java.util.Map).get(0),float) - %s), 2) + Math.pow((cast(cast(location.get(cast("coordinates",String)),java.util.Map).get(1),float) - %s), 2) %s Math.pow(%s,2) and' % \
+            text = u'%s Math.pow((cast(cast(%s.get(cast("coordinates",String)),java.util.Map).get(0),float) - %s), 2) + Math.pow((cast(cast(%s.get(cast("coordinates",String)),java.util.Map).get(1),float) - %s), 2) %s Math.pow(%s,2) and' % \
                    (text, rule_properties["attr_name"], rule_properties["location_x"], rule_properties["attr_name"], rule_properties["location_y"], rule_properties["attr_op"], rule_properties["location_ratio"])
-
-            ###  cast(location.get(cast("coordinates",String)),java.util.Map).get(0)
             #text = u'%s true and' % \
             #       (text)
         if "meta_value" in rule_properties:

--- a/iotqatools/cep_utils.py
+++ b/iotqatools/cep_utils.py
@@ -401,13 +401,14 @@ class CEP:
                    (text, rule_properties["attr_name"], data_type, rule_properties["attr_op"], rule_properties["attr_value"])
         if "timestamp_last_minutes" in rule_properties: #timestamp
             #text = u'%s cast(cast(%s__ts?,String),float) > current_timestamp - %s*60*1000 and' % \
-            text = u'%s cast(cast(%s?,String),float) > current_timestamp - %s and' % \
-                   (text, rule_properties["attr_name"], rule_properties["timestamp_last_minutes"])
+            #       (text, rule_properties["attr_name"], rule_properties["timestamp_last_minutes"])
+            text = u'%s true and' % \
+                   (text)
         if "location_x" in rule_properties:  # geo-location
             #text = u'%s Math.pow((cast(cast(%s__x?,String),float) - %s), 2) + Math.pow((cast(cast(%s__y?,String),float) - %s), 2) %s Math.pow(%s,2) and' % \
             #       (text, rule_properties["attr_name"], rule_properties["location_x"], rule_properties["attr_name"], rule_properties["location_y"], rule_properties["attr_op"], rule_properties["location_ratio"])
-            text = u'%s Math.pow((cast(cast(%s?,String),float) - %s), 2) + Math.pow((cast(cast(%s?,String),float) - %s), 2) %s Math.pow(%s,2) and' % \
-                   (text, rule_properties["attr_name"], rule_properties["location"], rule_properties["attr_name"], rule_properties["location"], rule_properties["attr_op"], rule_properties["location_ratio"])
+            text = u'%s true and' % \
+                   (text)
         if "meta_value" in rule_properties:
             value, data_type = get_type_value(str(rule_properties["meta_value"]))
             text = u'%s cast(cast(%s?,String),%s)%s%s and' % \

--- a/iotqatools/cep_utils.py
+++ b/iotqatools/cep_utils.py
@@ -407,7 +407,7 @@ class CEP:
         if "location_x" in rule_properties:  # geo-location
             #text = u'%s Math.pow((cast(cast(%s__x?,String),float) - %s), 2) + Math.pow((cast(cast(%s__y?,String),float) - %s), 2) %s Math.pow(%s,2) and' % \
             #       (text, rule_properties["attr_name"], rule_properties["location_x"], rule_properties["attr_name"], rule_properties["location_y"], rule_properties["attr_op"], rule_properties["location_ratio"])
-            text = u'%s Math.pow((cast(cast(%s.get(cast("coordinates",String)),java.util.ArrayList).get(0),float) - %s), 2) + Math.pow((cast(cast(%s.get(cast("coordinates",String)),java.util.ArrayList).get(1),float) - %s), 2) %s Math.pow(%s,2) and' % \
+            text = u'%s Math.pow((cast(cast(cast(%s, java.util.Map).get(cast("coordinates",String)),java.util.ArrayList).get(0),float) - %s), 2) + Math.pow((cast(cast(cast(%s, java.util.Map).get(cast("coordinates",String)),java.util.ArrayList).get(1),float) - %s), 2) %s Math.pow(%s,2) and' % \
                    (text, rule_properties["attr_name"], rule_properties["location_x"], rule_properties["attr_name"], rule_properties["location_y"], rule_properties["attr_op"], rule_properties["location_ratio"])
             #text = u'%s true and' % \
             #       (text)

--- a/iotqatools/cep_utils.py
+++ b/iotqatools/cep_utils.py
@@ -407,7 +407,7 @@ class CEP:
         if "location_x" in rule_properties:  # geo-location
             #text = u'%s Math.pow((cast(cast(%s__x?,String),float) - %s), 2) + Math.pow((cast(cast(%s__y?,String),float) - %s), 2) %s Math.pow(%s,2) and' % \
             #       (text, rule_properties["attr_name"], rule_properties["location_x"], rule_properties["attr_name"], rule_properties["location_y"], rule_properties["attr_op"], rule_properties["location_ratio"])
-            text = u'%s Math.pow((cast(cast(cast(%s, java.util.Map).get(cast("coordinates",String)),java.util.ArrayList).get(0),float) - %s), 2) + Math.pow((cast(cast(cast(%s, java.util.Map).get(cast("coordinates",String)),java.util.ArrayList).get(1),float) - %s), 2) %s Math.pow(%s,2) and' % \
+            text = u'%s Math.pow((cast(cast(cast(%s.get(cast("coordinates",String)),java.util.Map), java.utilArrayList).get(0),float) - %s), 2) + Math.pow((cast(cast(cast(%s.get(cast("coordinates",String)),java.util.Map), java.util.ArrayList).get(1),float) - %s), 2) %s Math.pow(%s,2) and' % \
                    (text, rule_properties["attr_name"], rule_properties["location_x"], rule_properties["attr_name"], rule_properties["location_y"], rule_properties["attr_op"], rule_properties["location_ratio"])
             #text = u'%s true and' % \
             #       (text)

--- a/iotqatools/cep_utils.py
+++ b/iotqatools/cep_utils.py
@@ -410,7 +410,7 @@ class CEP:
             #text = u'%s Math.pow((cast(cast(%s__x?,String),float) - %s), 2) + Math.pow((cast(cast(%s__y?,String),float) - %s), 2) %s Math.pow(%s,2) and' % \
             #       (text, rule_properties["attr_name"], rule_properties["location_x"], rule_properties["attr_name"], rule_properties["location_y"], rule_properties["attr_op"], rule_properties["location_ratio"])
             text = u'%s Math.pow((cast(cast(%s.coordinates.0?,String),float) - %s), 2) + Math.pow((cast(cast(%s.coordinates.1?,String),float) - %s), 2) %s Math.pow(%s,2) and' % \
-                   (text, rule_properties["attr_name"], rule_properties["location"], rule_properties["attr_name"], rule_properties["location"], rule_properties["attr_op"], rule_properties["location_ratio"])
+                   (text, rule_properties["attr_name"], rule_properties["location_x"], rule_properties["attr_name"], rule_properties["location_y"], rule_properties["attr_op"], rule_properties["location_ratio"])
             #text = u'%s true and' % \
             #       (text)
         if "meta_value" in rule_properties:

--- a/iotqatools/cep_utils.py
+++ b/iotqatools/cep_utils.py
@@ -402,15 +402,17 @@ class CEP:
         if "timestamp_last_minutes" in rule_properties: #timestamp
             #text = u'%s cast(cast(%s__ts?,String),float) > current_timestamp - %s*60*1000 and' % \
             #       (text, rule_properties["attr_name"], rule_properties["timestamp_last_minutes"])
-            text = u'%s cast(cast(%s?,string), long, dateformat:\'iso\')) > current_timestamp - %s*60*1000 and' % \
+            text = u'%s cast(cast(%s?,string), long, dateformat:\'iso\') > current_timestamp - %s*60*1000 and' % \
                    (text, rule_properties["attr_name"], rule_properties["timestamp_last_minutes"])
             #text = u'%s true and' % \
             #       (text)
         if "location_x" in rule_properties:  # geo-location
             #text = u'%s Math.pow((cast(cast(%s__x?,String),float) - %s), 2) + Math.pow((cast(cast(%s__y?,String),float) - %s), 2) %s Math.pow(%s,2) and' % \
             #       (text, rule_properties["attr_name"], rule_properties["location_x"], rule_properties["attr_name"], rule_properties["location_y"], rule_properties["attr_op"], rule_properties["location_ratio"])
-            text = u'%s true and' % \
-                   (text)
+            text = u'%s Math.pow((cast(cast(%s.coordinates.0?,String),float) - %s), 2) + Math.pow((cast(cast(%s.coordinates.1?,String),float) - %s), 2) %s Math.pow(%s,2) and' % \
+                   (text, rule_properties["attr_name"], rule_properties["location"], rule_properties["attr_name"], rule_properties["location"], rule_properties["attr_op"], rule_properties["location_ratio"])
+            #text = u'%s true and' % \
+            #       (text)
         if "meta_value" in rule_properties:
             value, data_type = get_type_value(str(rule_properties["meta_value"]))
             text = u'%s cast(cast(%s?,String),%s)%s%s and' % \

--- a/iotqatools/cep_utils.py
+++ b/iotqatools/cep_utils.py
@@ -405,7 +405,7 @@ class CEP:
         if "location_x" in rule_properties:  # geo-location
             #text = u'%s Math.pow((cast(cast(%s__x?,String),float) - %s), 2) + Math.pow((cast(cast(%s__y?,String),float) - %s), 2) %s Math.pow(%s,2) and' % \
             #       (text, rule_properties["attr_name"], rule_properties["location_x"], rule_properties["attr_name"], rule_properties["location_y"], rule_properties["attr_op"], rule_properties["location_ratio"])
-            text = u'%s Math.pow((cast(cast(cast(%s.get(cast("coordinates",String)),java.util.Map), java.utilArrayList).get(0),float) - %s), 2) + Math.pow((cast(cast(cast(%s.get(cast("coordinates",String)),java.util.Map), java.util.ArrayList).get(1),float) - %s), 2) %s Math.pow(%s,2) and' % \
+            text = u'%s Math.pow((cast(cast(cast(cast(%s?, java.util.HashMap).get("coordinates"), java.util.Collection).firstOf()),float) - %s), 2) + Math.pow((cast(cast(cast(cast(%s?, java.util.HashMap).get("coordinates"), java.util.Collection).secondOf()),float) - %s), 2) %s Math.pow(%s,2) and' % \
                    (text, rule_properties["attr_name"], rule_properties["location_x"], rule_properties["attr_name"], rule_properties["location_y"], rule_properties["attr_op"], rule_properties["location_ratio"])
             #text = u'%s true and' % \
             #       (text)

--- a/iotqatools/cep_utils.py
+++ b/iotqatools/cep_utils.py
@@ -403,12 +403,8 @@ class CEP:
             text = u'%s cast(cast(%s?,string), long, dateformat:\'iso\') > current_timestamp - %s*60*1000 and' % \
                    (text, rule_properties["attr_name"], rule_properties["timestamp_last_minutes"])
         if "location_x" in rule_properties:  # geo-location
-            #text = u'%s Math.pow((cast(cast(%s__x?,String),float) - %s), 2) + Math.pow((cast(cast(%s__y?,String),float) - %s), 2) %s Math.pow(%s,2) and' % \
-            #       (text, rule_properties["attr_name"], rule_properties["location_x"], rule_properties["attr_name"], rule_properties["location_y"], rule_properties["attr_op"], rule_properties["location_ratio"])
             text = u'%s Math.pow((cast(cast(cast(cast(%s?, java.util.HashMap).get("coordinates"), java.util.Collection).firstOf()),float) - %s), 2) + Math.pow((cast(cast(cast(cast(%s?, java.util.HashMap).get("coordinates"), java.util.Collection).secondOf()),float) - %s), 2) %s Math.pow(%s,2) and' % \
                    (text, rule_properties["attr_name"], rule_properties["location_x"], rule_properties["attr_name"], rule_properties["location_y"], rule_properties["attr_op"], rule_properties["location_ratio"])
-            #text = u'%s true and' % \
-            #       (text)
         if "meta_value" in rule_properties:
             value, data_type = get_type_value(str(rule_properties["meta_value"]))
             text = u'%s cast(cast(%s?,String),%s)%s%s and' % \

--- a/iotqatools/cep_utils.py
+++ b/iotqatools/cep_utils.py
@@ -401,11 +401,13 @@ class CEP:
                    (text, rule_properties["attr_name"], data_type, rule_properties["attr_op"], rule_properties["attr_value"])
         if "timestamp_last_minutes" in rule_properties: #timestamp
             #text = u'%s cast(cast(%s__ts?,String),float) > current_timestamp - %s*60*1000 and' % \
-            text = u'%s cast(cast(%s?,String),float) > current_timestamp and' % \
+            text = u'%s cast(cast(%s?,String),float) > current_timestamp - %s and' % \
                    (text, rule_properties["attr_name"], rule_properties["timestamp_last_minutes"])
         if "location_x" in rule_properties:  # geo-location
-            text = u'%s Math.pow((cast(cast(%s__x?,String),float) - %s), 2) + Math.pow((cast(cast(%s__y?,String),float) - %s), 2) %s Math.pow(%s,2) and' % \
-                   (text, rule_properties["attr_name"], rule_properties["location_x"], rule_properties["attr_name"], rule_properties["location_y"], rule_properties["attr_op"], rule_properties["location_ratio"])
+            #text = u'%s Math.pow((cast(cast(%s__x?,String),float) - %s), 2) + Math.pow((cast(cast(%s__y?,String),float) - %s), 2) %s Math.pow(%s,2) and' % \
+            #       (text, rule_properties["attr_name"], rule_properties["location_x"], rule_properties["attr_name"], rule_properties["location_y"], rule_properties["attr_op"], rule_properties["location_ratio"])
+            text = u'%s Math.pow((cast(cast(%s?,String),float) - %s), 2) + Math.pow((cast(cast(%s?,String),float) - %s), 2) %s Math.pow(%s,2) and' % \
+                   (text, rule_properties["attr_name"], rule_properties["location"], rule_properties["attr_name"], rule_properties["location"], rule_properties["attr_op"], rule_properties["location_ratio"])
         if "meta_value" in rule_properties:
             value, data_type = get_type_value(str(rule_properties["meta_value"]))
             text = u'%s cast(cast(%s?,String),%s)%s%s and' % \

--- a/iotqatools/cep_utils.py
+++ b/iotqatools/cep_utils.py
@@ -400,8 +400,6 @@ class CEP:
             text = u'%s cast(cast(%s?,String),%s)%s%s and' % \
                    (text, rule_properties["attr_name"], data_type, rule_properties["attr_op"], rule_properties["attr_value"])
         if "timestamp_last_minutes" in rule_properties: #timestamp
-            #text = u'%s cast(cast(%s__ts?,String),float) > current_timestamp - %s*60*1000 and' % \
-            #       (text, rule_properties["attr_name"], rule_properties["timestamp_last_minutes"])
             text = u'%s cast(cast(%s?,string), long, dateformat:\'iso\') > current_timestamp - %s*60*1000 and' % \
                    (text, rule_properties["attr_name"], rule_properties["timestamp_last_minutes"])
         if "location_x" in rule_properties:  # geo-location

--- a/iotqatools/cep_utils.py
+++ b/iotqatools/cep_utils.py
@@ -402,8 +402,10 @@ class CEP:
         if "timestamp_last_minutes" in rule_properties: #timestamp
             #text = u'%s cast(cast(%s__ts?,String),float) > current_timestamp - %s*60*1000 and' % \
             #       (text, rule_properties["attr_name"], rule_properties["timestamp_last_minutes"])
-            text = u'%s true and' % \
-                   (text)
+            text = u'%s cast(cast(%s?,string), long, dateformat:\'iso\')) > current_timestamp - %s*60*1000 and' % \
+                   (text, rule_properties["attr_name"], rule_properties["timestamp_last_minutes"])
+            #text = u'%s true and' % \
+            #       (text)
         if "location_x" in rule_properties:  # geo-location
             #text = u'%s Math.pow((cast(cast(%s__x?,String),float) - %s), 2) + Math.pow((cast(cast(%s__y?,String),float) - %s), 2) %s Math.pow(%s,2) and' % \
             #       (text, rule_properties["attr_name"], rule_properties["location_x"], rule_properties["attr_name"], rule_properties["location_y"], rule_properties["attr_op"], rule_properties["location_ratio"])

--- a/iotqatools/cep_utils.py
+++ b/iotqatools/cep_utils.py
@@ -400,7 +400,8 @@ class CEP:
             text = u'%s cast(cast(%s?,String),%s)%s%s and' % \
                    (text, rule_properties["attr_name"], data_type, rule_properties["attr_op"], rule_properties["attr_value"])
         if "timestamp_last_minutes" in rule_properties: #timestamp
-            text = u'%s cast(cast(%s__ts?,String),float) > current_timestamp - %s*60*1000 and' % \
+            #text = u'%s cast(cast(%s__ts?,String),float) > current_timestamp - %s*60*1000 and' % \
+            text = u'%s cast(cast(%s?,String),float) > current_timestamp and' % \
                    (text, rule_properties["attr_name"], rule_properties["timestamp_last_minutes"])
         if "location_x" in rule_properties:  # geo-location
             text = u'%s Math.pow((cast(cast(%s__x?,String),float) - %s), 2) + Math.pow((cast(cast(%s__y?,String),float) - %s), 2) %s Math.pow(%s,2) and' % \

--- a/iotqatools/cep_utils.py
+++ b/iotqatools/cep_utils.py
@@ -407,7 +407,7 @@ class CEP:
         if "location_x" in rule_properties:  # geo-location
             #text = u'%s Math.pow((cast(cast(%s__x?,String),float) - %s), 2) + Math.pow((cast(cast(%s__y?,String),float) - %s), 2) %s Math.pow(%s,2) and' % \
             #       (text, rule_properties["attr_name"], rule_properties["location_x"], rule_properties["attr_name"], rule_properties["location_y"], rule_properties["attr_op"], rule_properties["location_ratio"])
-            text = u'%s Math.pow((cast(cast(%s.get(cast("coordinates",String)),java.util.Map).get(0),float) - %s), 2) + Math.pow((cast(cast(%s.get(cast("coordinates",String)),java.util.Map).get(1),float) - %s), 2) %s Math.pow(%s,2) and' % \
+            text = u'%s Math.pow((cast(cast(%s.get(cast("coordinates",String)),java.util.ArrayList).get(0),float) - %s), 2) + Math.pow((cast(cast(%s.get(cast("coordinates",String)),java.util.ArrayList).get(1),float) - %s), 2) %s Math.pow(%s,2) and' % \
                    (text, rule_properties["attr_name"], rule_properties["location_x"], rule_properties["attr_name"], rule_properties["location_y"], rule_properties["attr_op"], rule_properties["location_ratio"])
             #text = u'%s true and' % \
             #       (text)

--- a/iotqatools/cep_utils.py
+++ b/iotqatools/cep_utils.py
@@ -404,13 +404,13 @@ class CEP:
             #       (text, rule_properties["attr_name"], rule_properties["timestamp_last_minutes"])
             text = u'%s cast(cast(%s?,string), long, dateformat:\'iso\') > current_timestamp - %s*60*1000 and' % \
                    (text, rule_properties["attr_name"], rule_properties["timestamp_last_minutes"])
-            #text = u'%s true and' % \
-            #       (text)
         if "location_x" in rule_properties:  # geo-location
             #text = u'%s Math.pow((cast(cast(%s__x?,String),float) - %s), 2) + Math.pow((cast(cast(%s__y?,String),float) - %s), 2) %s Math.pow(%s,2) and' % \
             #       (text, rule_properties["attr_name"], rule_properties["location_x"], rule_properties["attr_name"], rule_properties["location_y"], rule_properties["attr_op"], rule_properties["location_ratio"])
-            text = u'%s Math.pow((cast(cast(%s.coordinates.0?,String),float) - %s), 2) + Math.pow((cast(cast(%s.coordinates.1?,String),float) - %s), 2) %s Math.pow(%s,2) and' % \
+            text = u'%s Math.pow((cast(cast(location.get(cast("coordinates",String)),java.util.Map).get(0),float) - %s), 2) + Math.pow((cast(cast(location.get(cast("coordinates",String)),java.util.Map).get(1),float) - %s), 2) %s Math.pow(%s,2) and' % \
                    (text, rule_properties["attr_name"], rule_properties["location_x"], rule_properties["attr_name"], rule_properties["location_y"], rule_properties["attr_op"], rule_properties["location_ratio"])
+
+            ###  cast(location.get(cast("coordinates",String)),java.util.Map).get(0)
             #text = u'%s true and' % \
             #       (text)
         if "meta_value" in rule_properties:


### PR DESCRIPTION
The way of rules are created should be updated since cep https://github.com/telefonicaid/perseo-fe/pull/713 does not parse location and datetime

- [x] Timestamp done and working
- [x] Location done and working