### PR TITLE
Fix/python simulator

### DIFF
--- a/iotqatools/simulators/listen/python/notification_listener.py
+++ b/iotqatools/simulators/listen/python/notification_listener.py
@@ -37,6 +37,13 @@ from getopt import getopt, GetoptError
 import sys
 import os
 
+from threading import Lock
+import time
+
+notif_dict = {}
+notif_lock = Lock()
+
+
 def usage_and_exit(msg):
     """
     Print usage message and exit"
@@ -195,14 +202,15 @@ def process_notification(path=None):
     subserv = request.headers['fiware-servicepath']
 
     notif = {
+        'ts': time.time(),
         'verb': request.method,
         'url': request.base_url,
         'headers': dict(request.headers),
         'query_string': request.query_string,
         'payload': request.data
     }
-
-    store(notif_dict, notif, serv, subserv)
+    with notif_lock:
+        store(notif_dict, notif, serv, subserv)
 
     return Response(status=200)
 
@@ -230,7 +238,8 @@ def count():
 @app.route('/reset', methods=['GET'])
 def reset():
     global notif_dict
-    notif_dict = {}
+    with notif_lock:
+        notif_dict = {}
     return Response(status=200)
 
 # This is the key dictionary to store all received notifications. It is a double-key structure,
@@ -254,6 +263,6 @@ if __name__ == '__main__':
     if https:
         ctx = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)
         ctx.load_cert_chain(cert_file, key_file)
-        app.run(host=host, port=port, debug=True, ssl_context=ctx, use_reloader=False)
+        app.run(host=host, port=port, debug=False, ssl_context=ctx, use_reloader=False)
     else:
-        app.run(host=host, port=port, debug=True, use_reloader=False)
+        app.run(host=host, port=port, debug=False, use_reloader=False)

--- a/iotqatools/simulators/listen/python/notification_listener.py
+++ b/iotqatools/simulators/listen/python/notification_listener.py
@@ -40,7 +40,6 @@ import os
 from threading import Lock
 import time
 
-notif_dict = {}
 notif_lock = Lock()
 
 

--- a/iotqatools/simulators/listen/python/notification_listener.py
+++ b/iotqatools/simulators/listen/python/notification_listener.py
@@ -106,14 +106,16 @@ def get_last(d, serv, subserv):
     :param subserv: subservice
     :return the received notification or empty string if serv/subserv is not found
     """
-
     if serv not in d:
-        return ''
+        return None
 
     if subserv not in d[serv]:
-        return ''
+        return None
 
     l = len(d[serv][subserv])
+
+    if l == 0:
+        return None
 
     return d[serv][subserv][l - 1]
 
@@ -215,13 +217,15 @@ def process_notification(path=None):
 
 @app.route('/last_notification', methods=['GET'])
 def last_notification():
-
     global notif_dict
 
-    serv = request.headers['fiware-service']
-    subserv = request.headers['fiware-servicepath']
+    serv = request.headers.get('fiware-service', '')
+    subserv = request.headers.get('fiware-servicepath', '')
 
     s = get_last(notif_dict, serv, subserv)
+
+    if s == '':
+        return Response(status=204)
 
     return jsonify(s)
 

--- a/iotqatools/simulators/listen/python/notification_listener.py
+++ b/iotqatools/simulators/listen/python/notification_listener.py
@@ -225,7 +225,7 @@ def last_notification():
     s = get_last(notif_dict, serv, subserv)
 
     if not s:
-        return jsonify({})
+        return Response("{}", status=200, mimetype='application/json')
 
     return jsonify(s)
 

--- a/iotqatools/simulators/listen/python/notification_listener.py
+++ b/iotqatools/simulators/listen/python/notification_listener.py
@@ -224,8 +224,8 @@ def last_notification():
 
     s = get_last(notif_dict, serv, subserv)
 
-    if s == '' or s is None:
-        return Response(status=204)
+    if not s:
+        return jsonify({})
 
     return jsonify(s)
 

--- a/iotqatools/simulators/listen/python/notification_listener.py
+++ b/iotqatools/simulators/listen/python/notification_listener.py
@@ -224,7 +224,7 @@ def last_notification():
 
     s = get_last(notif_dict, serv, subserv)
 
-    if s == '':
+    if s == '' or s is None:
         return Response(status=204)
 
     return jsonify(s)


### PR DESCRIPTION
Fix for pep019 tests
These tests are failing since centos7 -> debian migration

When None notification is receive then response {} should have content-length 2 instead of  content-length 2 checked by 
cb_ngsiv2_step.py:1016
```python
    if int(n) == 1:
        assert context.resp.text != '{}', " ERROR, - without notification received"
    else:
        assert context.resp.text == '{}', " ERROR, - notification received"
```